### PR TITLE
Add docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,7 @@
+version: '2.1'
+
+services:
+  main:
+    build: .
+    labels: 
+      'io.balena.features.dbus': '1'

--- a/ntptest.py
+++ b/ntptest.py
@@ -16,7 +16,7 @@ $ dbus-send \
   org.freedesktop.DBus.Properties.GetAll \
   string:"org.freedesktop.timedate1"
 
-On resin.io devices need to set the system dbus address:
+On balena.io devices need to set the system dbus address:
 DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
 """
 from time import sleep


### PR DESCRIPTION
To serve as an example of using dbus in a multi-container app.

Change-type: patch
Signed-off-by: Roman Mazur <roman@balena.io>